### PR TITLE
Updated table creation naming convention for v0 features

### DIFF
--- a/database-scripts/create-tables.sql
+++ b/database-scripts/create-tables.sql
@@ -5,11 +5,12 @@ create schema if not exists ca;
 
 create table if not exists ca.bill (
 	bill_id integer primary key,
-	name text,
+	bill_name text,
 	bill_number text,
+	user_name text,
 	full_text text,
 	author text,
-	origin_house_id integer,
+	origin_chamber_id integer,
 	committee_id integer,
 	status text
 );
@@ -21,11 +22,18 @@ create table if not exists ca.bill_history (
 	entry_text text
 );
 
-create table if not exists ca.house_vote_result (
-	hosue_vote_result_id integer primary key,
+create table if not exists ca.bill_schedule (
+	bill_schedule_id integer primary key,
+	bill_id integer,
+	event_date date,
+	event_text text
+);
+
+create table if not exists ca.chamber_vote_result (
+	chamber_vote_result_id integer primary key,
 	vote_date date,
 	bill_id integer,
-	house_id integer,
+	chamber_id integer,
 	votes_for integer,
 	votes_against integer
 );
@@ -41,17 +49,44 @@ create table if not exists ca.committee_vote_result (
 
 
 
--- HOUSE AND COMMITTEE DATA
+-- CHAMBER AND COMMITTEE DATA
 
-create table if not exists ca.house (
-	house_id integer primary key,
+create table if not exists ca.chamber (
+	chamber_id integer primary key,
 	name text
 );
-insert into ca.house (house_id, name) values (1, 'Assembly'), (2, 'Senate');
+insert into ca.chamber (chamber_id, name) values (1, 'Assembly'), (2, 'Senate');
 
 create table if not exists ca.committee (
 	committee_id integer primary key,
-	house_id integer,
+	chamber_id integer,
 	name text,
 	webpage_link text
+);
+
+-- USER CUSTOMIZED DATA
+
+create table if not exists ca.bill_issue (
+    bill_issue_id integer primary key,
+    issue_id integer,
+    bill_id integer
+);
+
+create table if not exists ca.issue (
+    issue_id integer primary key,
+    issue_name text
+);
+
+create table if not exists ca.legislator_expected_vote (
+    legislator_expected_vote_id integer primary key,
+    legislator_id integer,
+    bill_id integer,
+    expected_vote text
+);
+
+create table if not exists ca.user_action (
+    user_action_id integer primary key,
+    bill_id integer,
+    date date,
+    action_type text
 );


### PR DESCRIPTION
- convert `house` >> `chamber` to be consistent with government language
- added `user_name` field to `bill` table for users to specify names for bills for internal usage
- created `bill_schedule`, `bill_issue`, `issue`, `legislator_expected_vote`, and `user_action` tables