### PR TITLE
Session-wise table population: Assembly committees + optimization

### DIFF
--- a/database-population/committee_scraper.py
+++ b/database-population/committee_scraper.py
@@ -1,0 +1,42 @@
+import scraper_utils
+# scrape standing committees: (name, chamber_id, url)
+# committee table: transform each committee name-link tuple for table insertion
+# for each committee link, scrape for "XYZ Members" title >> IF exists, pull names ELSE + "/membersstaff" to URL to pull
+assembly_cmte_home = "https://www.assembly.ca.gov/committees"
+senate_cmte_home = "https://www.senate.ca.gov/committees"
+
+
+def make_soup(chamber):
+    pat = None
+    chamber_url = None
+    if chamber == "assembly":
+        pat = "div[id='committees_wrapper']"
+        chamber_url = assembly_cmte_home
+    elif chamber == "senate":
+        pat = "div[id='block-view-committees-standing'] > div[class='content'] > div > div[class='view-content']"
+        chamber_url = senate_cmte_home
+    return scraper_utils.make_static_soup(chamber_url, pat)
+
+
+def get_assembly_cmte_urls():
+    source = make_soup("assembly")[0].select("li")
+    results = list()
+    for i in source:
+        cmte_name = i.text.strip()
+        cmte_url = i.find("a")["href"]
+        cmte_data = {
+            "name": cmte_name,
+            "webpage_link": cmte_url,
+            "chamber_id": 1
+        }
+        results.append(cmte_data)
+    return results
+
+
+def main():
+    for _ in get_assembly_cmte_urls():
+        print(_)
+
+
+if __name__ == "__main__":
+    main()

--- a/database-population/make_db_id.py
+++ b/database-population/make_db_id.py
@@ -1,0 +1,23 @@
+# Generate a random integer to act as internal ID sequence for data points
+from random import shuffle
+
+
+def map_digit_id(arr, input_field, result_field, give_mapping=False):
+    inputs = [obj[input_field] for obj in arr]
+    id_arr = list(range(1, len(inputs) + 1))
+    shuffle(id_arr)
+    mapping = dict(zip(inputs, id_arr))
+    for obj in arr:
+        obj[result_field] = mapping[obj[input_field]]
+    if give_mapping:
+        return arr, mapping
+    return arr
+
+
+def generate_digit_id(arr, result_field):
+    id_arr = list(range(1, len(arr) + 1))
+    shuffle(id_arr)
+    for i in range(len(arr)):
+        obj = arr[i]
+        obj[result_field] = id_arr[i]
+    return arr

--- a/database-population/scraper_utils.py
+++ b/database-population/scraper_utils.py
@@ -1,0 +1,12 @@
+from bs4 import BeautifulSoup as bs
+import urllib.request
+
+
+def make_static_soup(page, tag_pattern, make_request=True):  # HELPER FUNCTION
+    url = page
+    if make_request:
+        url = urllib.request.urlopen(page).read()
+    soup = bs(url, "html.parser")
+    return soup.select(tag_pattern)
+
+

--- a/database-scripts/drop-tables.sql
+++ b/database-scripts/drop-tables.sql
@@ -1,6 +1,10 @@
 drop table if exists ca.bill;
 drop table if exists ca.bill_history;
-drop table if exists ca.house_vote_result;
+drop table if exists ca.bill_schedule;
+drop table if exists ca.chamber_vote_result;
 drop table if exists ca.committee_vote_result;
-drop table if exists ca.house;
+drop table if exists ca.chamber;
+drop table if exists ca.chamber_schedule;
 drop table if exists ca.committee;
+drop table if exists ca.bill_issue;
+drop table if exists ca.issue


### PR DESCRIPTION
- Clears session-wise tables after connecting to DB
- Populates legislators AND Assembly committees (Senate committees -- TBD)
- Can be run locally once a session (or scheduled -- TBD)
- Realigns `drop-tables.sql` and `create-tables.sql` to include all tables in [updated DB schema](https://lucid.app/lucidchart/d0e43b13-6761-4ac5-9a8b-1af26bd65c60/edit?viewport_loc=-2334%2C-107%2C3152%2C1570%2C0_0&invitationId=inv_ccf623b9-8203-441c-a250-0c0e7bf7cb48)