### PR TITLE
22 senate updates to bill schedule

### DIFF
--- a/database-population/assembly_dailyfile_scraper.py
+++ b/database-population/assembly_dailyfile_scraper.py
@@ -5,25 +5,25 @@ from playwright.sync_api import sync_playwright
 import scraper_utils
 
 
-def normalize_bill_number(text):
-    return text.replace("No.", "").replace(".", "").strip()
+# def normalize_bill_number(text):
+#     return text.replace("No.", "").replace(".", "").strip()
 
 
-def collect_measures(event_date, event_description, sel):
-    results = set()
-    for measure in sel:
-        results.add((event_date, event_description, normalize_bill_number(measure.text)))
-    return results
+# def collect_measures(event_date, event_description, sel):
+#     results = set()
+#     for measure in sel:
+#         results.add((event_date, event_description, normalize_bill_number(measure.text)))
+#     return results
 
 
-def view_agenda(page, link):
-    try:
-        link.wait_for(state='attached')
-        link.click()
-        page.wait_for_timeout(1000) # Wait for content to load
-    except Exception as e:
-        return e
-    return
+# def view_agenda(page, link):
+#     try:
+#         link.wait_for(state='attached')
+#         link.click()
+#         page.wait_for_timeout(1000) # Wait for content to load
+#     except Exception as e:
+#         return e
+#     return
 
 def scrape_dailyfile(
         url="https://www.assembly.ca.gov/schedules-publications/assembly-daily-file"
@@ -35,7 +35,7 @@ def scrape_dailyfile(
         page = browser.new_page()
         page.goto(url)
         floor_session_agenda = page.get_by_role("link", name="View Agenda").first
-        view_agenda(page, floor_session_agenda)
+        scraper_utils.view_agenda(page, floor_session_agenda)
 
         # Extract HTML
         content = page.content()
@@ -53,7 +53,7 @@ def scrape_dailyfile(
                     for a in floor_actions:
                         # Extract measures AKA bills to be covered in the floor session and union with existing results
                         measures = a.find_next_sibling("div", class_="agenda-item").select("span.measureLink")
-                        floor_session_results = floor_session_results | collect_measures(floor_date, a.text.title(), measures)
+                        floor_session_results = floor_session_results | scraper_utils.collect_measures(floor_date, a.text.title(), measures)
             else:
                 hearing_description = section.select_one('div.header').text.title()
                 # Extract event date
@@ -62,7 +62,7 @@ def scrape_dailyfile(
                 # If agenda has been determined, extract specific measures
                 if agenda:
                     measures = agenda.select('span.measureLink')
-                    committee_hearing_results = committee_hearing_results | collect_measures(hearing_date, hearing_description, measures)
+                    committee_hearing_results = committee_hearing_results | scraper_utils.collect_measures(hearing_date, hearing_description, measures)
 
         browser.close()
     return floor_session_results | committee_hearing_results

--- a/database-population/scraper_utils.py
+++ b/database-population/scraper_utils.py
@@ -9,7 +9,6 @@ def text_to_date_string(s):
     except ValueError:
         pass
 
-
 def prettify_structure(content):
     soup = bs(content, 'html.parser')
 
@@ -19,6 +18,23 @@ def prettify_structure(content):
     print('***'*20)
     return
 
+def normalize_bill_number(text):
+    return text.replace("No.", "").replace(".", "").strip()
+
+def collect_measures(event_date, event_description, sel):
+    results = set()
+    for measure in sel:
+        results.add((event_date, event_description, normalize_bill_number(measure.text)))
+    return results
+
+def view_agenda(page, link):
+    try:
+        link.wait_for(state='attached')
+        link.click()
+        page.wait_for_timeout(1000) # Wait for content to load
+    except Exception as e:
+        return e
+    return
 
 def make_static_soup(page, tag_pattern, make_request=True):  # HELPER FUNCTION
     url = page

--- a/database-population/senate_dailyfile_scraper.py
+++ b/database-population/senate_dailyfile_scraper.py
@@ -1,0 +1,71 @@
+from bs4 import BeautifulSoup as bs
+import datetime
+from playwright.sync_api import sync_playwright
+import scraper_utils
+
+def scrape_dailyfile(
+        source_url="https://www.senate.ca.gov/calendar"
+):
+    start_date = datetime.date.today()
+    end_date = start_date + datetime.timedelta(days=30)
+    query_url = source_url + "?startDate=" + start_date.strftime("%Y-%m-%d") + "&endDate=" + end_date.strftime("%Y-%m-%d") + "&floorMeetings=1&committeeHearings=1"
+    
+    floor_session_results = set()
+    committee_hearing_results = set()
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(query_url)
+
+        # iterate over date wrapper blocks
+        page.wait_for_selector("div.page-events--day-wrapper")
+        wrappers = page.locator("div.page-events--day-wrapper")
+        wrapper_count = wrappers.count()
+
+        for i in range(wrapper_count):
+            # Extract current date
+            current_wrapper = wrappers.nth(i)
+            current_date = scraper_utils.text_to_date_string(current_wrapper.locator("h2.page-events__date").first.inner_text())
+            print(current_date)
+
+            # Detect empty content
+            empty_wrapper = page.locator("div.no-results-message")
+
+            if empty_wrapper.count() > 0:
+                print(f"No events scheduled for {current_date}")
+            else:
+                #TODO: Examine floor session content
+                            
+                # Examine committee hearing content
+                committee_hearing_section = current_wrapper.locator("div.dailyfile-section.committee-hearings")
+                hearing_elements = committee_hearing_section.locator("div.page-events__item.page-events__item--committee-hearing")
+
+                # Iterate over individual hearings
+                for j in range(hearing_elements.count()):
+                    current_hearing = hearing_elements.nth(j)
+                    current_name = current_hearing.locator("div.hearing-name").inner_text().title()
+                    print(current_name)
+                    current_agenda = current_hearing.get_by_role("link", name="View Agenda")
+                    scraper_utils.view_agenda(page, current_agenda)
+
+                    # Extract agenda content
+                    page.wait_for_selector("div.ui-dialog.ui-corner-all.ui-widget.ui-widget-content.ui-front.event-agenda-modal")
+                    content = page.locator("div.ui-dialog.ui-corner-all.ui-widget.ui-widget-content.ui-front.event-agenda-modal").inner_html()
+                    soup = bs(content, 'html.parser')
+
+                    # Extract measures
+                    committee_hearing_results = committee_hearing_results | scraper_utils.collect_measures(current_date, current_name, soup.select("span.measureLink"))
+
+                    # Close agenda pop-up
+                    close_button = page.get_by_role("button", name="Close").first
+                    close_button.click()
+
+        browser.close()
+    return floor_session_results | committee_hearing_results
+
+def main():
+    scrape_dailyfile()
+
+if __name__ == "__main__":
+    main()

--- a/database-population/upcoming_schedule_daily_update.py
+++ b/database-population/upcoming_schedule_daily_update.py
@@ -1,4 +1,5 @@
 import assembly_dailyfile_scraper as assembly
+import senate_dailyfile_scraper as senate
 import pandas as pd
 from config import config
 import psycopg2
@@ -96,7 +97,7 @@ def legtracker_update(cur, schedule_data):
 
 def fetch_schedule_update():
     assembly_update = assembly.scrape_dailyfile()
-    senate_update = set()
+    senate_update = senate.scrape_dailyfile()
     return assembly_update, senate_update
 
 


### PR DESCRIPTION
Refactors upcoming-schedule scraper code to remove redundancy between Assembly and Senate scraping. Daily scheduled script is updated with Senate committee hearing data scraping; comments have been added for the final touches to Senate floor session scraping. 