### PR TITLE
[BUGFIX] Assembly scraper HTML handling

### DIFF
--- a/database-population/bill_schedule_daily_update.py
+++ b/database-population/bill_schedule_daily_update.py
@@ -13,6 +13,7 @@ import psycopg2
 import pickle
 import os
 from tqdm import tqdm
+from datetime import datetime
 from db_utils import copy_temp_table
 
 SNAPSHOT_SCHEMA = config("postgresql_schemas")["snapshot_schema"]
@@ -350,7 +351,11 @@ def fetch_schedule_update(dev=False):
             final_changes = pickle.load(change_f)
 
     else:  # Otherwise, just fetch as normal
-        print("Fetching schedule updates...")
+        print(
+            "Current timestamp: "
+            + datetime.now().strftime("%Y-%m-%d, %H:%M:%S")
+            + " -- fetching schedule updates"
+        )
         assembly_update, assembly_changes = assembly.scrape_committee_hearing(verbose=True)
         senate_update, senate_changes = senate.scrape_committee_hearing(verbose=True)
 

--- a/database-population/committee_bill_asm_fetch.py
+++ b/database-population/committee_bill_asm_fetch.py
@@ -58,6 +58,8 @@ def scrape_committee_hearing(
 
         # for each hearing
         for i in range(hearing_count):
+            # Refetch
+            # hearing_rows = page.locator("tr.committee-hearing-details")
             current_hearing = hearing_rows.nth(i)
 
             # get date, name, time, location
@@ -88,12 +90,15 @@ def scrape_committee_hearing(
             if "View Agenda" not in row_menu_contents:
                 if verbose:
                     print(f"No agenda found for {hearing_name}, moving on...")
+                # Close the dropdown menu by clicking the button again
+                hearing_menu.click()
+                page.wait_for_timeout(500)
                 continue
             else:
                 print("Clicking current hearing agenda...")
                 agenda_link = current_hearing.locator('a[href*="/api/dailyfile/agenda"]')
-                scraper_utils.page_click(agenda_link)
-
+                scraper_utils.page_click(agenda_link, force=True)
+    
                 # Wait for the modal to be visible
                 page.wait_for_selector("div.agenda-container", state="visible", timeout=5000)
 
@@ -124,9 +129,13 @@ def scrape_committee_hearing(
                     committee_hearing_results | current_events_detailed
                 )
 
-                # Close agenda pop-up
-                close_button = page.get_by_role("button", name="Close").first
-                close_button.click()
+                # Close agenda modal
+                page.keyboard.press("Escape")
+                page.wait_for_timeout(500)
+
+                # Close the dropdown menu by clicking the button again
+                hearing_menu.click()
+                page.wait_for_timeout(500)
 
     except Exception as e:
         print(f"[ASM] Daily File scrape failed: {e}")

--- a/database-population/scraper_utils.py
+++ b/database-population/scraper_utils.py
@@ -94,14 +94,14 @@ def add_measure_details(event_time, event_location, event_room, measures):
     return results
 
 
-def page_click(clickable):
+def page_click(clickable, force=False):
     """
     Input: Playwright page object, pointer to clickable object
     Output: None (clicks the object)
     """
     try:
         clickable.wait_for(state="visible", timeout=5000)
-        clickable.click()
+        clickable.click(force=force)
     except Exception as e:
         print(f"Error: {e}")
         return e


### PR DESCRIPTION
Dropdown menu + hearing agenda modal elements are now properly closed at each step of the for-loop over all hearings.